### PR TITLE
Add onboarding flow and auth pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ create table users (
   id uuid primary key default uuid_generate_v4(),
   email text unique not null,
   created_at timestamp with time zone default now(),
-  generation_count integer default 0
+  generation_count integer default 0,
+  onboarded boolean default false
 );
 
 -- Table des documents

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase-client'
+
+export default function Dashboard() {
+  const router = useRouter()
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) router.push('/login')
+    })
+  }, [router])
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import AutoLogout from '@/components/auto-logout'
+import ToastProvider from '@/components/toaster'
 
 const inter = Inter({ 
   subsets: ['latin'],
@@ -30,6 +31,7 @@ export default function RootLayout({
     <html lang="fr" className="h-full">
       <body className={`${inter.className} h-full antialiased`}>
         <AutoLogout />
+        <ToastProvider />
         {children}
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { supabase } from '@/lib/supabase-client'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        router.push('/')
+      }
+    })
+  }, [router])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+    if (error) {
+      setError(error.message)
+    } else if (data.user) {
+      const { data: userRow } = await supabase
+        .from('users')
+        .select('onboarded')
+        .eq('id', data.user.id)
+        .single()
+      setSuccess('Connexion r\u00e9ussie !')
+      if (userRow && !userRow.onboarded) {
+        router.push('/onboarding')
+      } else {
+        router.push('/')
+      }
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-8 rounded-xl shadow-md space-y-4 w-full max-w-sm"
+      >
+        <h1 className="text-2xl font-bold text-center">Connexion</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        {success && <p className="text-green-600 text-sm">{success}</p>}
+        <button
+          type="submit"
+          className="w-full bg-gradient-to-r from-orange-400 to-amber-500 text-white px-4 py-2 rounded"
+        >
+          Se connecter
+        </button>
+        <p className="text-center text-sm">
+          Pas de compte?{' '}
+          <Link href="/register" className="text-orange-600 hover:underline">
+            Inscription
+          </Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+import OnboardingWizard from '@/components/onboarding/OnboardingWizard'
+
+export default function OnboardingPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <OnboardingWizard />
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,30 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import ModernWebApp from '@/components/ModernWebApp'
+import { supabase } from '@/lib/supabase-client'
 
 export default function Home() {
+  const router = useRouter()
+
+  useEffect(() => {
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session) {
+        router.push('/login')
+      } else {
+        const { data: user } = await supabase
+          .from('users')
+          .select('onboarded')
+          .eq('id', session.user.id)
+          .single()
+        if (user && !user.onboarded) {
+          router.push('/onboarding')
+        }
+      }
+    })
+  }, [router])
+
   return (
     <main className="min-h-screen">
       <ModernWebApp />

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase-client'
+
+export default function RegisterPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        router.push('/')
+      }
+    })
+  }, [router])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    const { data, error } = await supabase.auth.signUp({ email, password })
+    if (error || !data.user) {
+      setError(error?.message || 'Erreur inconnue')
+      return
+    }
+
+    await supabase.from('users').insert({ id: data.user.id, email, onboarded: false })
+
+    // Assurer la connexion de l'utilisateur apr\u00e8s l'inscription
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+    if (signInError) {
+      setError(signInError.message)
+      return
+    }
+
+    setSuccess("Inscription r\u00e9ussie !")
+    router.push('/onboarding')
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-8 rounded-xl shadow-md space-y-4 w-full max-w-sm"
+      >
+        <h1 className="text-2xl font-bold text-center">Inscription</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        {success && <p className="text-green-600 text-sm">{success}</p>}
+        <button
+          type="submit"
+          className="w-full bg-gradient-to-r from-orange-400 to-amber-500 text-white px-4 py-2 rounded"
+        >
+          S'inscrire
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/components/auto-logout.tsx
+++ b/components/auto-logout.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase-client'
+
+const INACTIVITY_LIMIT = 30 * 60 * 1000 // 30 minutes
+
+export default function AutoLogout() {
+  const router = useRouter()
+  const timer = useRef<NodeJS.Timeout | null>(null)
+
+  const resetTimer = () => {
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(async () => {
+      await supabase.auth.signOut()
+      router.push('/login')
+    }, INACTIVITY_LIMIT)
+  }
+
+  useEffect(() => {
+    const events = ['mousemove', 'keydown', 'click', 'scroll']
+    events.forEach((e) => window.addEventListener(e, resetTimer))
+    resetTimer()
+    return () => {
+      events.forEach((e) => window.removeEventListener(e, resetTimer))
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [])
+
+  return null
+}

--- a/components/onboarding/OnboardingWizard.tsx
+++ b/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,105 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase-client'
+import { AnimatePresence, motion } from 'framer-motion'
+import Progress from './Progress'
+import Step1, { Step1Data } from './Step1'
+import Step2, { Step2Data } from './Step2'
+import Step3, { Step3Data } from './Step3'
+
+interface Data extends Step1Data, Step2Data {}
+
+const STORAGE_KEY = 'onboarding'
+
+export default function OnboardingWizard() {
+  const router = useRouter()
+  const [step, setStep] = useState(0)
+  const [data, setData] = useState<Data>({ firstName: '', email: '' })
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) router.push('/login')
+    })
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      const parsed = JSON.parse(saved)
+      setStep(parsed.step || 0)
+      setData(parsed.data || { firstName: '', email: '' })
+    }
+  }, [router])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ step, data }))
+  }, [step, data])
+
+  const nextStep = (values: Partial<Data>) => {
+    setData((d) => ({ ...d, ...values }))
+    setStep((s) => Math.min(2, s + 1))
+  }
+
+  const prevStep = () => setStep((s) => Math.max(0, s - 1))
+
+  const finish = async () => {
+    localStorage.removeItem(STORAGE_KEY)
+    const { data: { session } } = await supabase.auth.getSession()
+    if (session) {
+      await supabase.from('users').update({ onboarded: true }).eq('id', session.user.id)
+    }
+    router.push('/dashboard')
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-6 bg-white rounded-xl shadow">
+      <Progress current={step} total={3} />
+      <AnimatePresence mode="wait">
+        {step === 0 && (
+          <motion.div
+            key="step1"
+            initial={{ opacity: 0, x: 50 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -50 }}
+            transition={{ duration: 0.3 }}
+          >
+            <Step1
+              defaultValues={{ firstName: data.firstName, email: data.email }}
+              onNext={(v) => nextStep(v)}
+            />
+          </motion.div>
+        )}
+        {step === 1 && (
+          <motion.div
+            key="step2"
+            initial={{ opacity: 0, x: 50 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -50 }}
+            transition={{ duration: 0.3 }}
+          >
+            <Step2
+              defaultValues={{ newsletter: data.newsletter, tips: data.tips }}
+              onNext={(v) => nextStep(v)}
+              onBack={prevStep}
+            />
+          </motion.div>
+        )}
+        {step === 2 && (
+          <motion.div
+            key="step3"
+            initial={{ opacity: 0, x: 50 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -50 }}
+            transition={{ duration: 0.3 }}
+          >
+            <Step3 data={data as Step3Data} onBack={prevStep} onFinish={finish} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+      <button
+        onClick={() => router.push('/dashboard')}
+        className="mt-4 text-sm text-gray-500 underline"
+      >
+        Ignorer l'onboarding
+      </button>
+    </div>
+  )
+}

--- a/components/onboarding/Progress.tsx
+++ b/components/onboarding/Progress.tsx
@@ -1,0 +1,16 @@
+'use client'
+interface ProgressProps {
+  current: number
+  total: number
+}
+export default function Progress({ current, total }: ProgressProps) {
+  const percent = ((current + 1) / total) * 100
+  return (
+    <div className="w-full h-2 bg-gray-200 rounded-full mb-6">
+      <div
+        className="h-2 bg-orange-500 rounded-full transition-all"
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  )
+}

--- a/components/onboarding/Step1.tsx
+++ b/components/onboarding/Step1.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+
+const schema = z.object({
+  firstName: z.string().min(1, 'Pr\u00e9nom requis'),
+  email: z.string().email('Email invalide'),
+})
+export type Step1Data = z.infer<typeof schema>
+
+interface Props {
+  defaultValues: Step1Data
+  onNext: (data: Step1Data) => void
+}
+
+export default function Step1({ defaultValues, onNext }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Step1Data>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  })
+
+  return (
+    <form onSubmit={handleSubmit(onNext)} className="space-y-4">
+      <div>
+        <label className="block mb-1 font-medium">Pr\u00e9nom</label>
+        <input
+          type="text"
+          {...register('firstName')}
+          className="w-full border rounded px-3 py-2"
+        />
+        {errors.firstName && (
+          <p className="text-red-500 text-sm">{errors.firstName.message}</p>
+        )}
+      </div>
+      <div>
+        <label className="block mb-1 font-medium">Email</label>
+        <input
+          type="email"
+          {...register('email')}
+          className="w-full border rounded px-3 py-2"
+        />
+        {errors.email && (
+          <p className="text-red-500 text-sm">{errors.email.message}</p>
+        )}
+      </div>
+      <button
+        type="submit"
+        className="bg-gradient-to-r from-orange-400 to-amber-500 text-white px-4 py-2 rounded"
+      >
+        Suivant
+      </button>
+    </form>
+  )
+}

--- a/components/onboarding/Step2.tsx
+++ b/components/onboarding/Step2.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+
+const schema = z.object({
+  newsletter: z.boolean().optional(),
+  tips: z.boolean().optional(),
+})
+export type Step2Data = z.infer<typeof schema>
+
+interface Props {
+  defaultValues: Step2Data
+  onNext: (data: Step2Data) => void
+  onBack: () => void
+}
+
+export default function Step2({ defaultValues, onNext, onBack }: Props) {
+  const {
+    register,
+    handleSubmit,
+  } = useForm<Step2Data>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  })
+
+  return (
+    <form onSubmit={handleSubmit(onNext)} className="space-y-4">
+      <div className="space-y-2">
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" {...register('newsletter')} className="h-4 w-4" />
+          <span>S\u2019abonner \u00e0 la newsletter</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" {...register('tips')} className="h-4 w-4" />
+          <span>Recevoir des astuces personnalis\u00e9es</span>
+        </label>
+      </div>
+      <div className="flex justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-4 py-2 rounded bg-gray-200"
+        >
+          Pr\u00e9c\u00e9dent
+        </button>
+        <button
+          type="submit"
+          className="px-4 py-2 rounded bg-gradient-to-r from-orange-400 to-amber-500 text-white"
+        >
+          Suivant
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/components/onboarding/Step3.tsx
+++ b/components/onboarding/Step3.tsx
@@ -1,0 +1,49 @@
+'use client'
+import toast from 'react-hot-toast'
+
+export interface Step3Data {
+  firstName: string
+  email: string
+  newsletter?: boolean
+  tips?: boolean
+}
+
+interface Props {
+  data: Step3Data
+  onBack: () => void
+  onFinish: () => void
+}
+
+export default function Step3({ data, onBack, onFinish }: Props) {
+  const handleFinish = () => {
+    toast.success(`Bienvenue ${data.firstName} !`)
+    onFinish()
+  }
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Confirmation</h2>
+      <p className="text-gray-700">Merci {data.firstName} ({data.email}).</p>
+      <p className="text-gray-700">Pr\u00e9f\u00e9rences :</p>
+      <ul className="list-disc pl-6 text-gray-700">
+        <li>{data.newsletter ? 'Inscrit \u00e0 la newsletter' : 'Pas de newsletter'}</li>
+        <li>{data.tips ? 'Recevoir des astuces' : 'Pas d\u2019astuces'}</li>
+      </ul>
+      <div className="flex justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-4 py-2 rounded bg-gray-200"
+        >
+          Pr\u00e9c\u00e9dent
+        </button>
+        <button
+          type="button"
+          onClick={handleFinish}
+          className="px-4 py-2 rounded bg-gradient-to-r from-orange-400 to-amber-500 text-white"
+        >
+          Terminer
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/toaster.tsx
+++ b/components/toaster.tsx
@@ -1,0 +1,5 @@
+'use client'
+import { Toaster } from 'react-hot-toast'
+export default function ToastProvider() {
+  return <Toaster position="top-right" />
+}

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -11,6 +11,7 @@ export interface User {
   email: string
   created_at: string
   generation_count: number
+  onboarded: boolean
 }
 
 export interface Document {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,21 @@
       "name": "cover-letter-codex",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.1.1",
         "@supabase/supabase-js": "^2.39.3",
         "autoprefixer": "^10.4.21",
+        "framer-motion": "^12.19.2",
         "lucide-react": "^0.263.1",
         "next": "14.1.0",
         "openai": "^4.24.0",
         "postcss": "^8.5.6",
         "react": "^18",
         "react-dom": "^18",
+        "react-hook-form": "^7.59.0",
+        "react-hot-toast": "^2.5.2",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5"
+        "typescript": "^5",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -134,6 +139,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -506,6 +523,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -1785,7 +1808,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2842,6 +2864,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.19.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.2.tgz",
+      "integrity": "sha512-0cWMLkYr+i0emeXC4hkLF+5aYpzo32nRdQ0D/5DI460B3O7biQ3l2BpDzIGsAHYuZ0fpBP0DC8XBkVf6RPAlZw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.19.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3081,6 +3130,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -4045,6 +4103,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
+      "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4798,6 +4871,39 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.59.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.59.0.tgz",
+      "integrity": "sha512-kmkek2/8grqarTJExFNjy+RXDIP8yM+QTl3QL6m6Q8b2bih4ltmiXxH7T9n+yXNK477xPh5yZT/6vD8sYGzJTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {
@@ -6271,6 +6377,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,16 +9,21 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "@supabase/supabase-js": "^2.39.3",
     "autoprefixer": "^10.4.21",
+    "framer-motion": "^12.19.2",
     "lucide-react": "^0.263.1",
     "next": "14.1.0",
     "openai": "^4.24.0",
     "postcss": "^8.5.6",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.59.0",
+    "react-hot-toast": "^2.5.2",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
- restore login, register and onboarding pages
- add onboarding wizard components
- show toast notifications and auto logout
- add dashboard page and session/onboarding checks
- add onboarding flag to Supabase User type and docs
- install form and animation dependencies

## Testing
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6860d9fcda848325a3efbd9bb4ba9cf4