### PR TITLE
Fix missing supabase import

### DIFF
--- a/components/auto-logout.tsx
+++ b/components/auto-logout.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase-client'
 
 
 const INACTIVITY_LIMIT = 30 * 60 * 1000 // 30 minutes


### PR DESCRIPTION
## Summary
- add missing supabase import in `components/auto-logout.tsx`

## Testing
- `npm run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6863938d1a4083258ddd4c804f362c6b