### PR TITLE
Add user_profiles table

### DIFF
--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -101,6 +101,41 @@ export type Database = {
                     created_at?: string
                     updated_at?: string
                 }
+            },
+            user_profiles: {
+                Row: {
+                    user_id: string
+                    first_name: string | null
+                    last_name: string | null
+                    phone: string | null
+                    country: string | null
+                    language: string | null
+                    birth_date: string | null
+                    created_at: string | null
+                    updated_at: string | null
+                }
+                Insert: {
+                    user_id: string
+                    first_name?: string | null
+                    last_name?: string | null
+                    phone?: string | null
+                    country?: string | null
+                    language?: string | null
+                    birth_date?: string | null
+                    created_at?: string | null
+                    updated_at?: string | null
+                }
+                Update: {
+                    user_id?: string
+                    first_name?: string | null
+                    last_name?: string | null
+                    phone?: string | null
+                    country?: string | null
+                    language?: string | null
+                    birth_date?: string | null
+                    created_at?: string | null
+                    updated_at?: string | null
+                }
             }
         }
     }
@@ -143,4 +178,6 @@ export const db = {
         supabase.from('saved_letters'),
     userQuotas: () =>
         supabase.from('user_quotas'),
+    userProfiles: () =>
+        supabase.from('user_profiles'),
 }

--- a/supabase/migrations/0001_create_user_profiles.sql
+++ b/supabase/migrations/0001_create_user_profiles.sql
@@ -1,0 +1,16 @@
+create table if not exists user_profiles (
+  user_id uuid primary key references users(id) on delete cascade,
+  first_name text,
+  last_name text,
+  phone text,
+  country text,
+  language text,
+  birth_date date,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table user_profiles enable row level security;
+
+create policy "Allow individual user access" on user_profiles
+  for all using ( auth.uid() = user_id );


### PR DESCRIPTION
## Summary
- add SQL migration for `user_profiles`
- update Supabase typings with new table
- expose `userProfiles` helper

## Testing
- `npm run format`
- `npm run lint` *(fails: `next: not found`)*
- `npm run type-check` *(fails: missing modules)*
- `npm install` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_686393905228832593db6007666732dd