### PR TITLE
Fix Supabase import paths

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import OpenAI from 'openai'
-import { supabase } from '@/lib/supabase'
+import { supabase } from '@/lib/supabase-client'
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,

--- a/components/CVUpload.tsx
+++ b/components/CVUpload.tsx
@@ -18,7 +18,7 @@ import {
     AlertCircle
 } from 'lucide-react'
 import toast from 'react-hot-toast'
-import { supabase } from '@/lib/supabase-Client'
+import { supabase } from '@/lib/supabase-client'
 import { useUser } from '@/hooks/useUser'
 
 interface CVUploadProps {

--- a/components/LetterPreview.tsx
+++ b/components/LetterPreview.tsx
@@ -18,7 +18,7 @@ import {
   Save
 } from 'lucide-react'
 import toast from 'react-hot-toast'
-import { supabase } from '@/lib/supabase-Client'
+import { supabase } from '@/lib/supabase-client'
 import html2pdf from 'html2pdf.js'
 import { useUser } from '@/hooks/useUser'
 

--- a/hooks/useUser.tsx
+++ b/hooks/useUser.tsx
@@ -1,6 +1,6 @@
 ﻿import { useEffect, useState } from 'react'
 import { User } from '@supabase/supabase-js'
-import { supabase } from '@/lib/supabase-Client'
+import { supabase } from '@/lib/supabase-client'
 
 export function useUser() {
     const [user, setUser] = useState<User | null>(null)

--- a/lib/api/letter-generation.ts
+++ b/lib/api/letter-generation.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabaseClient'
+import { supabase } from '@/lib/supabase-client'
 
 interface GenerateLetterParams {
     profile: {
@@ -25,7 +25,7 @@ interface GenerateLetterParams {
 }
 
 export async function generateLetter(params: GenerateLetterParams): Promise<string> {
-    // Appel à votre API OpenAI
+    // Appel Ã  votre API OpenAI
     const response = await fetch('/api/generate-letter', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -33,7 +33,7 @@ export async function generateLetter(params: GenerateLetterParams): Promise<stri
     })
 
     if (!response.ok) {
-        throw new Error('Erreur lors de la génération')
+        throw new Error('Erreur lors de la gÃ©nÃ©ration')
     }
 
     const data = await response.json()


### PR DESCRIPTION
## Summary
- unify all Supabase imports to use `lib/supabase-client`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: cannot fetch @types/html2pdf.js from registry)*

------
https://chatgpt.com/codex/tasks/task_e_6863936f00b8832592de75181ddb5870