### PR TITLE
Add document upload page with OCR extraction

### DIFF
--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import Header from '@/components/Header'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { languages } from '@/lib/data/languages'
+import { uploadDocument } from '@/services/supabase'
+import { useUser } from '@/hooks/useUser'
+import ProfileTable from '@/components/ProfileTable'
+import { useExtractCVData } from '@/hooks/useExtractCVData'
+
+export default function DocumentUploadPage() {
+  const router = useRouter()
+  const { user, loading: userLoading } = useUser()
+
+  const [file, setFile] = useState<File | null>(null)
+  const [title, setTitle] = useState('')
+  const [language, setLanguage] = useState('')
+  const [description, setDescription] = useState('')
+  const [uploading, setUploading] = useState(false)
+  const [profileId, setProfileId] = useState<string | null>(null)
+  const [filePath, setFilePath] = useState<string | null>(null)
+
+  const { data: extracted } = useExtractCVData(profileId, filePath)
+
+  useEffect(() => {
+    if (!userLoading && !user) router.push('/login')
+  }, [userLoading, user, router])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!user || !file) return
+    setUploading(true)
+    try {
+      const { id, path } = await uploadDocument({
+        userId: user.id,
+        file,
+        title,
+        language,
+        description,
+      })
+      setProfileId(id)
+      setFilePath(path)
+    } catch (error) {
+      console.error(error)
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-amber-50">
+      <Header />
+      <div className="container py-10">
+        <Card className="max-w-xl mx-auto">
+          <CardHeader>
+            <CardTitle>Téléverser un document</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <Input
+                type="file"
+                accept=".jpg,.jpeg,.png,.txt,.pdf"
+                onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+              />
+              <Input
+                type="text"
+                name="title"
+                placeholder="Titre du document"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
+              <select
+                name="language"
+                value={language}
+                onChange={(e) => setLanguage(e.target.value)}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              >
+                <option value="">-- Langue --</option>
+                {languages.map((l) => (
+                  <option key={l.code} value={l.code}>
+                    {l.flag} {l.label}
+                  </option>
+                ))}
+              </select>
+              <Textarea
+                name="description"
+                placeholder="Description (optionnel)"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+              <Button type="submit" disabled={uploading}>
+                {uploading ? 'Envoi...' : 'Envoyer'}
+              </Button>
+            </form>
+            {extracted && (
+              <div className="mt-8">
+                <ProfileTable data={extracted} />
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
+import Link from 'next/link'
 import { Sparkles, Menu, X } from 'lucide-react'
 
 const Header = () => {
@@ -18,10 +19,10 @@ const Header = () => {
           </div>
 
           <nav className="hidden md:flex space-x-8">
-            <a href="./" className="text-gray-700 hover:text-orange-600 transition-colors">Dashboard</a>
-            <a href="#" className="text-gray-700 hover:text-orange-600 transition-colors">Documents</a>
+            <Link href="/" className="text-gray-700 hover:text-orange-600 transition-colors">Dashboard</Link>
+            <Link href="/upload" className="text-gray-700 hover:text-orange-600 transition-colors">Documents</Link>
             <a href="#" className="text-gray-700 hover:text-orange-600 transition-colors">Générateur</a>
-            <a href="./profile" className="text-gray-700 hover:text-orange-600 transition-colors">Profil</a>
+            <Link href="/profile" className="text-gray-700 hover:text-orange-600 transition-colors">Profil</Link>
           </nav>
 
           <button
@@ -37,10 +38,10 @@ const Header = () => {
       {isMenuOpen && (
         <div className="md:hidden bg-white border-t border-gray-200">
           <div className="px-4 py-2 space-y-1">
-            <a href="#" className="block px-3 py-2 text-gray-700 hover:bg-gray-50 rounded-md">Dashboard</a>
-            <a href="#" className="block px-3 py-2 text-gray-700 hover:bg-gray-50 rounded-md">Documents</a>
+            <Link href="/" className="block px-3 py-2 text-gray-700 hover:bg-gray-50 rounded-md">Dashboard</Link>
+            <Link href="/upload" className="block px-3 py-2 text-gray-700 hover:bg-gray-50 rounded-md">Documents</Link>
             <a href="#" className="block px-3 py-2 text-gray-700 hover:bg-gray-50 rounded-md">Générateur</a>
-            <a href="#" className="block px-3 py-2 text-gray-700 hover:bg-gray-50 rounded-md">Profil</a>
+            <Link href="/profile" className="block px-3 py-2 text-gray-700 hover:bg-gray-50 rounded-md">Profil</Link>
           </div>
         </div>
       )}

--- a/components/ProfileTable.tsx
+++ b/components/ProfileTable.tsx
@@ -1,0 +1,75 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export interface ProfileTableProps {
+  data: {
+    first_name?: string
+    last_name?: string
+    experiences?: string[]
+    skills?: string[]
+    education?: string[]
+  }
+}
+
+export default function ProfileTable({ data }: ProfileTableProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Profil extrait</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-sm">
+          <tbody>
+            {data.first_name && (
+              <tr>
+                <td className="font-medium pr-4">Prénom</td>
+                <td>{data.first_name}</td>
+              </tr>
+            )}
+            {data.last_name && (
+              <tr>
+                <td className="font-medium pr-4">Nom</td>
+                <td>{data.last_name}</td>
+              </tr>
+            )}
+            {data.experiences && data.experiences.length > 0 && (
+              <tr>
+                <td className="font-medium pr-4 align-top">Expériences</td>
+                <td>
+                  <ul className="list-disc pl-4 space-y-1">
+                    {data.experiences.map((exp, i) => (
+                      <li key={i}>{exp}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            )}
+            {data.skills && data.skills.length > 0 && (
+              <tr>
+                <td className="font-medium pr-4 align-top">Compétences</td>
+                <td>
+                  <ul className="list-disc pl-4 space-y-1">
+                    {data.skills.map((s, i) => (
+                      <li key={i}>{s}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            )}
+            {data.education && data.education.length > 0 && (
+              <tr>
+                <td className="font-medium pr-4 align-top">Formation</td>
+                <td>
+                  <ul className="list-disc pl-4 space-y-1">
+                    {data.education.map((e, i) => (
+                      <li key={i}>{e}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/hooks/useExtractCVData.ts
+++ b/hooks/useExtractCVData.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react'
+import Tesseract from 'tesseract.js'
+import { supabase } from '@/lib/supabase-client'
+
+export interface ExtractedProfile {
+  first_name?: string
+  last_name?: string
+  experiences?: string[]
+  skills?: string[]
+  education?: string[]
+}
+
+export function useExtractCVData(
+  profileId: string | null,
+  filePath: string | null,
+) {
+  const [data, setData] = useState<ExtractedProfile | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!profileId || !filePath) return
+
+    const run = async () => {
+      setLoading(true)
+      try {
+        const { data: file, error: dlError } = await supabase.storage
+          .from('documents')
+          .download(filePath)
+        if (dlError || !file) throw dlError || new Error('download failed')
+
+        let text = ''
+        if (filePath.endsWith('.txt')) {
+          text = await file.text()
+        } else {
+          const { data: ocr } = await Tesseract.recognize(file, 'fra+eng')
+          text = ocr.text
+        }
+
+        const extracted = parseText(text)
+
+        await supabase
+          .from('candidates_profile')
+          .update(extracted)
+          .eq('id', profileId)
+
+        setData(extracted)
+      } catch (e: any) {
+        console.error(e)
+        setError(e.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    run()
+  }, [profileId, filePath])
+
+  return { data, loading, error }
+}
+
+function parseText(text: string): ExtractedProfile {
+  const firstNameMatch = text.match(/Pr[eé]nom[:\s]+([A-Za-zÀ-ÖØ-öø-ÿ'-]+)/i)
+  const lastNameMatch = text.match(/Nom[:\s]+([A-Za-zÀ-ÖØ-öø-ÿ'-]+)/i)
+
+  const expMatch = text.match(/(?:Exp[ée]riences?|Experience)([\s\S]*?)(?:Comp[ée]tences|Skills|$)/i)
+  const experiences = expMatch
+    ? expMatch[1].split(/\n+/).map((v) => v.trim()).filter(Boolean)
+    : undefined
+
+  const skillsMatch = text.match(/(?:Comp[ée]tences|Skills)([\s\S]*?)(?:Formation|Education|$)/i)
+  const skills = skillsMatch
+    ? skillsMatch[1].split(/[,\n]+/).map((v) => v.trim()).filter(Boolean)
+    : undefined
+
+  const eduMatch = text.match(/(?:Formation|Education)([\s\S]*?)(?:Exp[ée]riences?|Skills|$)/i)
+  const education = eduMatch
+    ? eduMatch[1].split(/\n+/).map((v) => v.trim()).filter(Boolean)
+    : undefined
+
+  return {
+    first_name: firstNameMatch ? firstNameMatch[1] : undefined,
+    last_name: lastNameMatch ? lastNameMatch[1] : undefined,
+    experiences,
+    skills,
+    education,
+  }
+}

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -168,6 +168,50 @@ export type Database = {
           flag?: string;
         };
       };
+      candidates_profile: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          language: string;
+          description: string | null;
+          file_url: string;
+          uploaded_at: string;
+          first_name: string | null;
+          last_name: string | null;
+          experiences: string[] | null;
+          skills: string[] | null;
+          education: string[] | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          title: string;
+          language: string;
+          description?: string | null;
+          file_url: string;
+          uploaded_at?: string;
+          first_name?: string | null;
+          last_name?: string | null;
+          experiences?: string[] | null;
+          skills?: string[] | null;
+          education?: string[] | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          language?: string;
+          description?: string | null;
+          file_url?: string;
+          uploaded_at?: string;
+          first_name?: string | null;
+          last_name?: string | null;
+          experiences?: string[] | null;
+          skills?: string[] | null;
+          education?: string[] | null;
+        };
+      };
     };
   };
 };
@@ -209,4 +253,5 @@ export const db = {
   userProfiles: () => supabase.from("user_profiles"),
   countries: () => supabase.from("countries"),
   languages: () => supabase.from("languages"),
+  candidatesProfile: () => supabase.from("candidates_profile"),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-phone-number-input": "^3.4.12",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
+        "tesseract.js": "^4.0.2",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -2611,6 +2612,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4502,6 +4509,12 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4757,6 +4770,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4982,6 +5001,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -5813,6 +5838,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6335,8 +6369,7 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -7219,6 +7252,31 @@
         }
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-4.1.4.tgz",
+      "integrity": "sha512-iLjJjLWVNV4PApofEsd54Y1MbjhzpPxEzF8EjYmC2CLN4hrUqO5aTNTSbGA7/QjycKtAWHhn2YmDR+6GFwi2Zg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-electron": "^2.2.2",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^4.0.4",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-4.0.4.tgz",
+      "integrity": "sha512-MJ+vtktjAaT0681uPl6TDUPhbRbpD/S9emko5rtorgHRZpQo7R3BG7h+3pVHgn1KjfNf1bvnx4B7KxEK8YKqpg==",
+      "license": "Apache License 2.0"
+    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -7591,6 +7649,12 @@
         "base64-arraybuffer": "^1.0.2"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -7875,6 +7939,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^11.12.0",
     "html2pdf.js": "^0.10.2",
+    "tesseract.js": "^4.0.2",
     "lodash": "^4.17.21",
     "react-phone-number-input": "^3.4.12",
     "lucide-react": "^0.460.0",

--- a/services/supabase.ts
+++ b/services/supabase.ts
@@ -1,0 +1,41 @@
+import { supabase } from '@/lib/supabase-client'
+
+export interface UploadDocumentArgs {
+  userId: string
+  file: File
+  title: string
+  language: string
+  description?: string
+}
+
+export async function uploadDocument({
+  userId,
+  file,
+  title,
+  language,
+  description,
+}: UploadDocumentArgs): Promise<{ id: string; path: string }> {
+  const extension = file.name.split('.').pop()
+  const path = `${userId}/${Date.now()}.${extension}`
+
+  const { error: uploadError } = await supabase.storage
+    .from('documents')
+    .upload(path, file)
+  if (uploadError) throw uploadError
+
+  const { data, error } = await supabase
+    .from('candidates_profile')
+    .insert({
+      user_id: userId,
+      title,
+      language,
+      description,
+      file_url: path,
+      uploaded_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single()
+  if (error) throw error
+
+  return { id: data.id, path }
+}

--- a/supabase/migrations/0003_create_candidates_profile.sql
+++ b/supabase/migrations/0003_create_candidates_profile.sql
@@ -1,0 +1,19 @@
+create table if not exists candidates_profile (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade,
+  title text not null,
+  language text not null,
+  description text,
+  file_url text not null,
+  uploaded_at timestamptz default now(),
+  first_name text,
+  last_name text,
+  experiences text[],
+  skills text[],
+  education text[]
+);
+
+alter table candidates_profile enable row level security;
+
+create policy "Allow individual user access" on candidates_profile
+  for all using ( auth.uid() = user_id );


### PR DESCRIPTION
## Summary
- link Documents header to `/upload`
- add Supabase service helpers for uploading documents
- implement OCR extraction hook
- show extracted data via new ProfileTable component
- create document upload page and wire to header
- extend Supabase database types for `candidates_profile`
- add `tesseract.js` dependency

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm run type-check` *(fails: cannot find modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871d80cf3e8832599c4a3a5ece0acb5