### PR TITLE
Add vertical tabs to profile page

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -17,6 +17,10 @@ import { codeToFlagEmoji, Country } from "@/lib/data/countries";
 import { Language } from "@/lib/data/languages";
 import { Button } from "@/components/ui/button";
 import Header from "@/components/Header";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import CVUpload from "@/components/CVUpload";
+import ProfileSettings from "@/components/ProfileSettings";
+import SubscriptionInfo from "@/components/SubscriptionInfo";
 
 interface Profile {
   first_name: string;
@@ -146,105 +150,133 @@ export default function ProfilePage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-50 via-white to-amber-50">
-      {/* Header */}
       <Header />
-      {/* Main Content */}
-      <div className="flex items-center justify-center py-10">
-        <Card className="w-full max-w-xl">
-          <CardHeader>
-            <CardTitle>Mon Profil</CardTitle>
-          </CardHeader>
-          <form onSubmit={handleSubmit}>
-            <CardContent className="space-y-4">
-              <div>
-                <Label htmlFor="first_name">Prénom</Label>
-                <Input
-                  id="first_name"
-                  name="first_name"
-                  value={profile.first_name}
-                  onChange={handleChange}
-                />
-              </div>
-              <div>
-                <Label htmlFor="last_name">Nom</Label>
-                <Input
-                  id="last_name"
-                  name="last_name"
-                  value={profile.last_name}
-                  onChange={handleChange}
-                />
-              </div>
-              <div>
-                <Label htmlFor="phone">Téléphone</Label>
-                <PhoneInput
-                  id="phone"
-                  name="phone"
-                  defaultCountry="FR"
-                  value={profile.phone || undefined}
-                  onChange={(value) => {
-                    setPhoneError(null);
-                    setProfile((prev) => ({ ...prev, phone: value || "" }));
-                  }}
-                  international
-                />
-                {phoneError && (
-                  <p className="text-red-500 text-sm">{phoneError}</p>
-                )}
-              </div>
-              <div>
-                <Label htmlFor="country">Pays</Label>
-                <select
-                  id="country"
-                  name="country"
-                  value={profile.country}
-                  onChange={handleChange}
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                >
-                  <option value="">-- Sélectionner --</option>
-                  {countries.map((c) => (
-                    <option key={c.code} value={c.code}>
-                      {codeToFlagEmoji(c.code)} {c.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <Label htmlFor="language">Langue</Label>
-                <select
-                  id="language"
-                  name="language"
-                  value={profile.language}
-                  onChange={handleChange}
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                >
-                  <option value="">-- Sélectionner --</option>
-                  {languages.map((l) => (
-                    <option key={l.code} value={l.code}>
-                      {l.flag} {l.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <Label htmlFor="birth_date">Date de naissance</Label>
-                <Input
-                  id="birth_date"
-                  name="birth_date"
-                  type="date"
-                  value={profile.birth_date}
-                  onChange={handleChange}
-                />
-              </div>
-              {error && <p className="text-red-500 text-sm">{error}</p>}
-              {success && <p className="text-green-600 text-sm">{success}</p>}
-            </CardContent>
-            <CardFooter>
-              <Button type="submit" className="ml-auto">
-                Enregistrer
-              </Button>
-            </CardFooter>
-          </form>
-        </Card>
+      <div className="flex justify-center py-10">
+        <Tabs
+          defaultValue="profile"
+          orientation="vertical"
+          className="flex w-full max-w-4xl gap-4"
+        >
+          <TabsList className="w-40">
+            <TabsTrigger value="profile">Profil</TabsTrigger>
+            <TabsTrigger value="cv">CV</TabsTrigger>
+            <TabsTrigger value="settings">Paramètres</TabsTrigger>
+            <TabsTrigger value="subscription">Abonnement</TabsTrigger>
+          </TabsList>
+          <div className="flex-1">
+            <TabsContent value="profile">
+              <Card className="w-full">
+                <CardHeader>
+                  <CardTitle>Mon Profil</CardTitle>
+                </CardHeader>
+                <form onSubmit={handleSubmit}>
+                  <CardContent className="space-y-4">
+                    <div>
+                      <Label htmlFor="first_name">Prénom</Label>
+                      <Input
+                        id="first_name"
+                        name="first_name"
+                        value={profile.first_name}
+                        onChange={handleChange}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="last_name">Nom</Label>
+                      <Input
+                        id="last_name"
+                        name="last_name"
+                        value={profile.last_name}
+                        onChange={handleChange}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="phone">Téléphone</Label>
+                      <PhoneInput
+                        id="phone"
+                        name="phone"
+                        defaultCountry="FR"
+                        value={profile.phone || undefined}
+                        onChange={(value) => {
+                          setPhoneError(null);
+                          setProfile((prev) => ({
+                            ...prev,
+                            phone: value || "",
+                          }));
+                        }}
+                        international
+                      />
+                      {phoneError && (
+                        <p className="text-red-500 text-sm">{phoneError}</p>
+                      )}
+                    </div>
+                    <div>
+                      <Label htmlFor="country">Pays</Label>
+                      <select
+                        id="country"
+                        name="country"
+                        value={profile.country}
+                        onChange={handleChange}
+                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                      >
+                        <option value="">-- Sélectionner --</option>
+                        {countries.map((c) => (
+                          <option key={c.code} value={c.code}>
+                            {codeToFlagEmoji(c.code)} {c.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <Label htmlFor="language">Langue</Label>
+                      <select
+                        id="language"
+                        name="language"
+                        value={profile.language}
+                        onChange={handleChange}
+                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                      >
+                        <option value="">-- Sélectionner --</option>
+                        {languages.map((l) => (
+                          <option key={l.code} value={l.code}>
+                            {l.flag} {l.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <Label htmlFor="birth_date">Date de naissance</Label>
+                      <Input
+                        id="birth_date"
+                        name="birth_date"
+                        type="date"
+                        value={profile.birth_date}
+                        onChange={handleChange}
+                      />
+                    </div>
+                    {error && <p className="text-red-500 text-sm">{error}</p>}
+                    {success && (
+                      <p className="text-green-600 text-sm">{success}</p>
+                    )}
+                  </CardContent>
+                  <CardFooter>
+                    <Button type="submit" className="ml-auto">
+                      Enregistrer
+                    </Button>
+                  </CardFooter>
+                </form>
+              </Card>
+            </TabsContent>
+            <TabsContent value="cv">
+              <CVUpload />
+            </TabsContent>
+            <TabsContent value="settings">
+              <ProfileSettings />
+            </TabsContent>
+            <TabsContent value="subscription">
+              <SubscriptionInfo />
+            </TabsContent>
+          </div>
+        </Tabs>
       </div>
     </div>
   );

--- a/components/ProfileSettings.tsx
+++ b/components/ProfileSettings.tsx
@@ -1,0 +1,3 @@
+export default function ProfileSettings() {
+  return <div className="p-6">Paramètres du profil à venir</div>;
+}

--- a/components/SubscriptionInfo.tsx
+++ b/components/SubscriptionInfo.tsx
@@ -1,0 +1,3 @@
+export default function SubscriptionInfo() {
+  return <div className="p-6">Informations d'abonnement à venir</div>;
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,55 +1,55 @@
+"use client";
 
-"use client"
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "@/lib/utils";
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
-import { cn } from "@/lib/utils"
-
-const Tabs = TabsPrimitive.Root
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
-    React.ElementRef<typeof TabsPrimitive.List>,
-    React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
-    <TabsPrimitive.List
-        ref={ref}
-        className={cn(
-            "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-            className
-        )}
-        {...props}
-    />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "data-[orientation=vertical]:flex-col",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
-    React.ElementRef<typeof TabsPrimitive.Trigger>,
-    React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-    <TabsPrimitive.Trigger
-        ref={ref}
-        className={cn(
-            "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-            className
-        )}
-        {...props}
-    />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
-    React.ElementRef<typeof TabsPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
-    <TabsPrimitive.Content
-        ref={ref}
-        className={cn(
-            "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-            className
-        )}
-        {...props}
-    />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };


### PR DESCRIPTION
## Summary
- enable vertical orientation styles for `TabsList`
- add placeholder components for profile settings and subscription info
- use Radix UI tabs on the profile page with CV, Settings and Subscription tabs

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module '@/components/ModernWebApp', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6872f294b83483258fe6afabc64da568