### PR TITLE
Connect profile tab to Supabase

### DIFF
--- a/lib/profile-utils.ts
+++ b/lib/profile-utils.ts
@@ -1,11 +1,14 @@
 
 import { supabase } from './supabase-client'
 
-export async function updateUserProfile(userId: string, updates: any) {
+// Met à jour ou crée le profil utilisateur dans la table `user_profiles`
+export async function updateUserProfile(
+  userId: string,
+  updates: Record<string, any>
+) {
   const { data, error } = await supabase
-    .from('users')
-    .update(updates)
-    .eq('id', userId)
+    .from('user_profiles')
+    .upsert({ user_id: userId, ...updates }, { onConflict: 'user_id', returning: 'representation' })
     .select()
     .single()
 

--- a/supabase/migrations/0004_add_fields_user_profiles.sql
+++ b/supabase/migrations/0004_add_fields_user_profiles.sql
@@ -1,0 +1,4 @@
+alter table if exists user_profiles
+  add column if not exists bio text,
+  add column if not exists avatar_url text;
+


### PR DESCRIPTION
## Summary
- fetch and persist profile information using Supabase
- adjust helper to upsert data into `user_profiles`
- add migration to store avatar and bio

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module '@/components/ModernWebApp', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6873147dd5b4832593c2f2f1e041fec9