### PR TITLE
Add OpenAI-based CV extraction

### DIFF
--- a/app/api/extract-cv/route.ts
+++ b/app/api/extract-cv/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import OpenAI from 'openai'
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+export async function POST(request: NextRequest) {
+  try {
+    const { text } = await request.json()
+    if (!text) {
+      return NextResponse.json({ error: 'Texte manquant' }, { status: 400 })
+    }
+
+    const prompt = `
+      Extract the following information in JSON:
+      - first_name
+      - last_name
+      - experiences (array)
+      - skills (array)
+      - education (array)
+      Resume text:
+      ${text}
+    `
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0
+    })
+
+    const content = completion.choices[0].message?.content || '{}'
+    const data = JSON.parse(content)
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: "Erreur lors de l'extraction" }, { status: 500 })
+  }
+}
+


### PR DESCRIPTION
## Summary
- create API route `extract-cv` to parse resume text using OpenAI
- update `useExtractCVData` hook to call new API after retrieving file text

## Testing
- `npm run type-check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687319edc3a88325ad9e37a984059be1