### PR TITLE
feat: Add multilingual support for PDF template UI components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,7 @@ L'API Brevo implémente plusieurs couches de protection :
 Uses OpenAI File API with GPT-4-turbo model. Files are temporarily stored in `/tmp` and cleaned up after processing.
 
 ### PDF Generation
-The application includes a comprehensive PDF generation system with multiple templates and customization options:
+The application includes a comprehensive PDF generation system with multiple templates and multilingual UI:
 
 #### Core System (`lib/pdf.ts`)
 - `generateLetterPdf(letterHtml, fileName, options?)` - Generates PDF from HTML string
@@ -431,19 +431,33 @@ The application includes a comprehensive PDF generation system with multiple tem
 
 #### Template System (`lib/pdf-templates.ts`)
 **4 Professional Templates Available:**
-- **Classic**: Traditional French style with Times New Roman (banking, legal, administration)
-- **Modern**: Clean contemporary design with Helvetica (tech, startups)
-- **Elegant**: Sophisticated with gradient header (consulting, luxury)
-- **Creative**: Colorful modern style with emojis (design, marketing)
+- **Classique**: Traditional French style with Times New Roman (banking, legal, administration)
+- **Moderne**: Clean contemporary design with Helvetica (tech, startups)
+- **Élégant**: Sophisticated with gradient header (consulting, luxury)
+- **Créatif**: Colorful modern style with emojis (design, marketing)
+
+#### Multilingual UI Support
+**Template selection interface translated in 5 languages:**
+- **5 Languages Supported**: French (fr), English (en), Spanish (es), German (de), Italian (it)
+- **UI Translations**: Template names, descriptions, and selection interface in all languages
+- **i18n Integration**: Uses existing `lib/i18n` system under `pdfTemplates` key
+- **PDF Content**: Templates generate French business letters with dynamic AI content
+- **Consistent Experience**: UI language follows user's selected locale
+
+#### Template Content Strategy
+- **French Format**: All PDF templates use standard French business letter format
+- **Dynamic Content**: Letter content comes from AI generation in user's chosen language
+- **Cultural Consistency**: Maintains French business correspondence conventions
+- **AI Integration**: AI-generated content is inserted into structured French templates
 
 #### UI Components
 - **`PdfExportControls`**: Complete export interface with template selection
-- **`TemplateSelector`**: Standalone template picker with visual previews
+- **`TemplateSelector`**: Standalone template picker with visual previews and translations
 - **Integration examples**: Available in `examples/pdf-integration-example.tsx`
 
 #### Usage in Components
-- **LetterPreview**: Can use either legacy system or new template system
-- **LetterCard**: Supports both approaches for saved letters
+- **LetterPreview**: Template selection UI shows translated names/descriptions
+- **LetterCard**: Supports template selection with localized interface
 - **Configurable options**: margin, format (a4/letter/legal), orientation, quality, scale, templateId
 
 #### Advanced Features
@@ -452,9 +466,11 @@ The application includes a comprehensive PDF generation system with multiple tem
 - **Automatic Data Mapping**: Converts app data to template format
 - **Error Handling**: Comprehensive logging and user-friendly messages
 - **Performance**: Client-side generation, no server dependencies
+- **Consistent Translation System**: Leverages existing i18n infrastructure for UI only
 
 #### Dependencies
 - `html2pdf.js` - Core PDF generation library (dynamically imported)
+- `lib/i18n` - Existing internationalization system for UI translations
 - Supports high-quality output with customizable options
 - Automatic cleanup of temporary DOM elements and object URLs
 
@@ -533,3 +549,8 @@ ADMIN_SECRET=lettercraft-admin-secret-2025
 
 ### Authentication
 Supabase auth with session persistence. `AutoLogout` component handles session management.
+
+## Translation System
+- **Multilingual UI Implementation**: Ensure translation of all UI for the following languages
+  - Add multilingual support across all UI components
+  - Traduire en multilingue toutes les UI que tu implementer (FR, EN, ES, GE, IT)

--- a/components/pdf/PdfExportControls.tsx
+++ b/components/pdf/PdfExportControls.tsx
@@ -47,11 +47,11 @@ export default function PdfExportControls({
       await generateLetterPdfWithTemplate(letterData, fileName, options)
       
       console.log('PDF generation successful')
-      toast.success('PDF téléchargé avec succès')
+      toast.success(t('letter.pdfDownloaded'))
       
     } catch (error) {
       console.error('PDF generation error:', error)
-      toast.error(`Erreur lors de la génération du PDF: ${error instanceof Error ? error.message : 'Erreur inconnue'}`)
+      toast.error(`${t('letter.generateError')}: ${error instanceof Error ? error.message : t('auth.unknownError')}`)
     } finally {
       setIsGeneratingPdf(false)
     }
@@ -61,10 +61,10 @@ export default function PdfExportControls({
     setIsGeneratingTxt(true)
     try {
       generateTextFile(letterData.content, fileName)
-      toast.success('Fichier texte téléchargé')
+      toast.success(t('letter.txtDownloaded'))
     } catch (error) {
       console.error('TXT generation error:', error)
-      toast.error('Erreur lors de la génération du fichier texte')
+      toast.error(t('letter.generateError'))
     } finally {
       setIsGeneratingTxt(false)
     }
@@ -78,17 +78,17 @@ export default function PdfExportControls({
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
               <Settings className="h-5 w-5 text-muted-foreground" />
-              <h3 className="font-semibold">Options d'export</h3>
+              <h3 className="font-semibold">{t('letter.exportOptions')}</h3>
             </div>
             <Badge variant="outline" className="text-xs">
-              Modèles disponibles: 4
+              {t('pdfTemplates.templatesAvailable')}: 4
             </Badge>
           </div>
 
           {/* Sélecteur de modèle */}
           <div className="space-y-2">
             <label className="text-sm font-medium text-muted-foreground">
-              Modèle de lettre
+              {t('pdfTemplates.titleFull')}
             </label>
             <TemplateSelector
               selectedTemplateId={selectedTemplateId}
@@ -107,7 +107,7 @@ export default function PdfExportControls({
               {isGeneratingPdf ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Génération...
+                  {t('common.generating')}
                 </>
               ) : (
                 <>
@@ -126,7 +126,7 @@ export default function PdfExportControls({
               {isGeneratingTxt ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Export...
+                  {t('common.downloading')}
                 </>
               ) : (
                 <>
@@ -139,9 +139,9 @@ export default function PdfExportControls({
 
           {/* Informations sur le fichier */}
           <div className="text-xs text-muted-foreground bg-muted/50 p-2 rounded">
-            <strong>Nom du fichier:</strong> {fileName}.pdf<br />
-            <strong>Format:</strong> A4, haute qualité<br />
-            <strong>Modèle:</strong> {selectedTemplateId}
+            <strong>{t('letter.fileName')}:</strong> {fileName}.pdf<br />
+            <strong>{t('letter.format')}:</strong> A4, {t('letter.highQuality')}<br />
+            <strong>{t('pdfTemplates.title')}:</strong> {t(`pdfTemplates.templates.${selectedTemplateId}.name`)}
           </div>
         </div>
       </CardContent>

--- a/components/pdf/TemplateSelector.tsx
+++ b/components/pdf/TemplateSelector.tsx
@@ -14,6 +14,7 @@ import {
   Zap
 } from 'lucide-react'
 import { PDF_TEMPLATES, PdfTemplate } from '@/lib/pdf-templates'
+import { useI18n } from '@/lib/i18n-context'
 
 interface TemplateSelectorProps {
   selectedTemplateId?: string
@@ -41,6 +42,7 @@ export default function TemplateSelector({
   className = ''
 }: TemplateSelectorProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const { t } = useI18n()
   
   const selectedTemplate = PDF_TEMPLATES.find(t => t.id === selectedTemplateId) || PDF_TEMPLATES[0]
 
@@ -57,7 +59,7 @@ export default function TemplateSelector({
         onClick={() => setIsOpen(!isOpen)}
       >
         <Palette className="h-4 w-4 mr-2" />
-        Modèle: {selectedTemplate.name}
+        {t('pdfTemplates.title')}: {t(`pdfTemplates.templates.${selectedTemplate.id}.name`)}
       </Button>
       
       {isOpen && (
@@ -67,7 +69,7 @@ export default function TemplateSelector({
               <div className="flex items-center justify-between mb-6">
                 <h2 className="text-xl font-semibold flex items-center">
                   <Palette className="h-5 w-5 mr-2" />
-                  Choisir un modèle de lettre
+                  {t('pdfTemplates.titleFull')}
                 </h2>
                 <Button variant="outline" onClick={() => setIsOpen(false)}>
                   ✕
@@ -93,12 +95,12 @@ export default function TemplateSelector({
                     <CardTitle className="flex items-center justify-between">
                       <div className="flex items-center">
                         <Icon className="h-5 w-5 mr-2" />
-                        {template.name}
+                        {t(`pdfTemplates.templates.${template.id}.name`)}
                       </div>
                       {isSelected && (
                         <Badge variant="default" className="bg-green-500">
                           <Check className="h-3 w-3 mr-1" />
-                          Sélectionné
+                          {t('pdfTemplates.selected')}
                         </Badge>
                       )}
                     </CardTitle>
@@ -106,7 +108,7 @@ export default function TemplateSelector({
                   
                   <CardContent>
                     <p className="text-sm text-muted-foreground mb-3">
-                      {template.description}
+                      {t(`pdfTemplates.templates.${template.id}.description`)}
                     </p>
                     
                     {/* Aperçu miniature du style */}
@@ -165,11 +167,11 @@ export default function TemplateSelector({
           
               <div className="flex justify-between items-center pt-4 border-t mt-6">
                 <p className="text-sm text-muted-foreground">
-                  Sélectionnez un modèle qui correspond à votre secteur d'activité
+                  {t('pdfTemplates.subtitleFull')}
                 </p>
                 <Button variant="outline" onClick={() => setIsOpen(false)}>
                   <Eye className="h-4 w-4 mr-2" />
-                  Fermer
+                  {t('pdfTemplates.close')}
                 </Button>
               </div>
             </div>

--- a/lib/i18n/de.json
+++ b/lib/i18n/de.json
@@ -486,7 +486,11 @@
     "backToDashboard": "Zurück zum Dashboard",
     "createNew": "Neuen Brief erstellen",
     "view": "Ansehen",
-    "generatedOn": "Erstellt am {date}"
+    "generatedOn": "Erstellt am {date}",
+    "exportOptions": "Export-Optionen",
+    "fileName": "Dateiname",
+    "format": "Format",
+    "highQuality": "hohe Qualität"
   },
   "questionnaire": {
     "experience": "Erfahrung",
@@ -691,5 +695,34 @@
         "subscriptionCancelledNote": "Sie erhalten eine Bestätigungs-E-Mail. Sie können die Kontolöschung noch vor dem geplanten Datum widerrufen."
       }
     }
+  },
+  "pdfTemplates": {
+    "title": "Vorlage wählen",
+    "subtitle": "Wählen Sie den Stil für Ihr Anschreiben",
+    "titleFull": "Brief-Vorlage wählen",
+    "subtitleFull": "Wählen Sie eine Vorlage, die zu Ihrer Branche passt",
+    "close": "Schließen",
+    "templatesAvailable": "Verfügbare Vorlagen",
+    "templates": {
+      "classic": {
+        "name": "Klassisch",
+        "description": "Traditioneller französischer Stil mit Times New Roman"
+      },
+      "modern": {
+        "name": "Modern", 
+        "description": "Sauberes und zeitgemäßes Design"
+      },
+      "elegant": {
+        "name": "Elegant",
+        "description": "Anspruchsvolles Design mit Farbakzenten"
+      },
+      "creative": {
+        "name": "Kreativ",
+        "description": "Modernes und farbenfrohes Design für kreative Berufe"
+      }
+    },
+    "preview": "Vorschau",
+    "select": "Auswählen",
+    "selected": "Ausgewählt"
   }
 }

--- a/lib/i18n/en.json
+++ b/lib/i18n/en.json
@@ -486,7 +486,11 @@
     "backToDashboard": "Back to dashboard",
     "createNew": "Create new letter",
     "view": "View",
-    "generatedOn": "Generated on {date}"
+    "generatedOn": "Generated on {date}",
+    "exportOptions": "Export options",
+    "fileName": "File name",
+    "format": "Format",
+    "highQuality": "high quality"
   },
   "questionnaire": {
     "experience": "Experience",
@@ -651,5 +655,34 @@
       "backToHome": "Back to home",
       "success": "Deletion request created successfully"
     }
+  },
+  "pdfTemplates": {
+    "title": "Choose a template",
+    "subtitle": "Select the style for your cover letter",
+    "titleFull": "Choose a letter template",
+    "subtitleFull": "Select a template that matches your industry",
+    "close": "Close",
+    "templatesAvailable": "Available templates",
+    "templates": {
+      "classic": {
+        "name": "Classic",
+        "description": "Traditional French style with Times New Roman"
+      },
+      "modern": {
+        "name": "Modern", 
+        "description": "Clean and contemporary design"
+      },
+      "elegant": {
+        "name": "Elegant",
+        "description": "Sophisticated design with color touches"
+      },
+      "creative": {
+        "name": "Creative",
+        "description": "Modern and colorful design for creative professions"
+      }
+    },
+    "preview": "Preview",
+    "select": "Select",
+    "selected": "Selected"
   }
 }

--- a/lib/i18n/es.json
+++ b/lib/i18n/es.json
@@ -486,7 +486,11 @@
     "backToDashboard": "Volver al panel",
     "createNew": "Crear nueva carta",
     "view": "Ver",
-    "generatedOn": "Generada el {date}"
+    "generatedOn": "Generada el {date}",
+    "exportOptions": "Opciones de exportación",
+    "fileName": "Nombre del archivo",
+    "format": "Formato",
+    "highQuality": "alta calidad"
   },
   "questionnaire": {
     "experience": "Experiencia",
@@ -651,5 +655,34 @@
       "backToHome": "Volver al inicio",
       "success": "Solicitud de eliminación creada con éxito"
     }
+  },
+  "pdfTemplates": {
+    "title": "Elegir una plantilla",
+    "subtitle": "Selecciona el estilo de tu carta de presentación",
+    "titleFull": "Elegir una plantilla de carta",
+    "subtitleFull": "Selecciona una plantilla que se adapte a tu sector de actividad",
+    "close": "Cerrar",
+    "templatesAvailable": "Plantillas disponibles",
+    "templates": {
+      "classic": {
+        "name": "Clásico",
+        "description": "Estilo tradicional francés con Times New Roman"
+      },
+      "modern": {
+        "name": "Moderno", 
+        "description": "Diseño limpio y contemporáneo"
+      },
+      "elegant": {
+        "name": "Elegante",
+        "description": "Diseño sofisticado con toques de color"
+      },
+      "creative": {
+        "name": "Creativo",
+        "description": "Diseño moderno y colorido para profesiones creativas"
+      }
+    },
+    "preview": "Vista previa",
+    "select": "Seleccionar",
+    "selected": "Seleccionado"
   }
 }

--- a/lib/i18n/fr.json
+++ b/lib/i18n/fr.json
@@ -486,7 +486,11 @@
     "backToDashboard": "Retour au tableau de bord",
     "createNew": "Créer une nouvelle lettre",
     "view": "Voir",
-    "generatedOn": "Générée le {date}"
+    "generatedOn": "Générée le {date}",
+    "exportOptions": "Options d'export",
+    "fileName": "Nom du fichier",
+    "format": "Format",
+    "highQuality": "haute qualité"
   },
   "questionnaire": {
     "experience": "Expérience",
@@ -691,5 +695,34 @@
         "subscriptionCancelledNote": "Vous recevrez un email de confirmation. Vous pouvez encore annuler la suppression de compte avant la date programmée."
       }
     }
+  },
+  "pdfTemplates": {
+    "title": "Choisir un modèle",
+    "subtitle": "Sélectionnez le style de votre lettre de motivation",
+    "titleFull": "Choisir un modèle de lettre",
+    "subtitleFull": "Sélectionnez un modèle qui correspond à votre secteur d'activité",
+    "close": "Fermer",
+    "templatesAvailable": "Modèles disponibles",
+    "templates": {
+      "classic": {
+        "name": "Classique",
+        "description": "Style traditionnel français avec Times New Roman"
+      },
+      "modern": {
+        "name": "Moderne", 
+        "description": "Design épuré et contemporain"
+      },
+      "elegant": {
+        "name": "Élégant",
+        "description": "Design sophistiqué avec touches de couleur"
+      },
+      "creative": {
+        "name": "Créatif",
+        "description": "Design moderne et coloré pour les métiers créatifs"
+      }
+    },
+    "preview": "Aperçu",
+    "select": "Sélectionner",
+    "selected": "Sélectionné"
   }
 }

--- a/lib/i18n/it.json
+++ b/lib/i18n/it.json
@@ -486,7 +486,11 @@
     "backToDashboard": "Torna alla dashboard",
     "createNew": "Crea una nuova lettera",
     "view": "Visualizza",
-    "generatedOn": "Generata il {date}"
+    "generatedOn": "Generata il {date}",
+    "exportOptions": "Opzioni di esportazione",
+    "fileName": "Nome del file",
+    "format": "Formato",
+    "highQuality": "alta qualità"
   },
   "questionnaire": {
     "experience": "Esperienza",
@@ -691,5 +695,34 @@
         "subscriptionCancelledNote": "Riceverai un'email di conferma. Puoi ancora annullare l'eliminazione dell'account prima della data programmata."
       }
     }
+  },
+  "pdfTemplates": {
+    "title": "Scegli un modello",
+    "subtitle": "Seleziona lo stile per la tua lettera di presentazione",
+    "titleFull": "Scegli un modello di lettera",
+    "subtitleFull": "Seleziona un modello che corrisponda al tuo settore di attività",
+    "close": "Chiudi",
+    "templatesAvailable": "Modelli disponibili",
+    "templates": {
+      "classic": {
+        "name": "Classico",
+        "description": "Stile tradizionale francese con Times New Roman"
+      },
+      "modern": {
+        "name": "Moderno", 
+        "description": "Design pulito e contemporaneo"
+      },
+      "elegant": {
+        "name": "Elegante",
+        "description": "Design sofisticato con tocchi di colore"
+      },
+      "creative": {
+        "name": "Creativo",
+        "description": "Design moderno e colorato per professioni creative"
+      }
+    },
+    "preview": "Anteprima",
+    "select": "Seleziona",
+    "selected": "Selezionato"
   }
 }

--- a/lib/pdf-templates.ts
+++ b/lib/pdf-templates.ts
@@ -2,6 +2,7 @@
  * PDF Templates for Letter Generation
  * 
  * This module provides different PDF templates with various styles and layouts
+ * PDF content is in French with dynamic content from AI generation
  */
 
 export interface LetterData {
@@ -25,7 +26,7 @@ export interface PdfTemplate {
 }
 
 /**
- * Template 1: Classique Français (Default)
+ * Template 1: Classique Français
  * Style traditionnel avec police Times New Roman
  */
 const classicTemplate: PdfTemplate = {


### PR DESCRIPTION
## Summary

• Add comprehensive multilingual support for PDF template selection UI
• Update PDF template components to use i18n translations instead of hardcoded French text  
• Add translations for 5 languages: French, English, Spanish, German, Italian
• Maintain French PDF format with AI-generated dynamic content as intended

## Key Changes

**UI Components Updated:**
- **`TemplateSelector.tsx`**: Convert all hardcoded French text to i18n translations
- **`PdfExportControls.tsx`**: Add multilingual support for export interface
- Dynamic template names and descriptions based on user's selected language

**New Translation Keys Added:**
- `pdfTemplates.titleFull`: "Choose a letter template" / "Choisir un modèle de lettre"
- `pdfTemplates.subtitleFull`: Industry-specific template selection guidance
- `pdfTemplates.close`: Modal close button
- `pdfTemplates.templatesAvailable`: Available templates count
- `letter.exportOptions`: Export options header
- `letter.fileName`, `letter.format`, `letter.highQuality`: File info labels

**Supported Languages:**
- 🇫🇷 French (Français) 
- 🇺🇸 English
- 🇪🇸 Spanish (Español)
- 🇩🇪 German (Deutsch)
- 🇮🇹 Italian (Italiano)

## Technical Approach

**UI-Only Multilingual Strategy:**
- ✅ Template selection interface fully translated
- ✅ PDF content remains in French business format
- ✅ AI-generated letter content inserted dynamically
- ✅ Leverages existing i18n infrastructure

## Test Plan

- [x] Build compiles successfully with all translations
- [x] Template selector shows translated names/descriptions
- [x] Export controls display in correct language
- [x] PDF generation works with all language interfaces
- [x] All 5 languages tested for UI completeness

🤖 Generated with [Claude Code](https://claude.ai/code)