### PR TITLE
fix: Repair upgrade button redirection to subscription tab

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -76,7 +76,13 @@ function ProfileContent() {
   return (
     <>
       <Header />
-      <ProfileLayout />
+      <Suspense fallback={
+        <div className="flex items-center justify-center py-10">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-500"></div>
+        </div>
+      }>
+        <ProfileLayout />
+      </Suspense>
     </>
   )
 }

--- a/components/profile/ProfileLayout.tsx
+++ b/components/profile/ProfileLayout.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { User, Settings, CreditCard, FileText, LogOut } from 'lucide-react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase-client'
 import { Card, CardContent } from '@/components/ui/card'
 import ProfileTab from './tabs/ProfileTab'
@@ -19,7 +19,16 @@ export default function ProfileLayout() {
     const { t } = useI18n()
     const [activeTab, setActiveTab] = useState<TabType>('profile')
     const router = useRouter()
+    const searchParams = useSearchParams()
     const { user, userProfile, loading, refreshProfile } = useUserSubscription()
+
+    // Lire le paramètre tab de l'URL au chargement du composant
+    useEffect(() => {
+        const tabParam = searchParams.get('tab') as TabType
+        if (tabParam && ['profile', 'cv', 'settings', 'subscription'].includes(tabParam)) {
+            setActiveTab(tabParam)
+        }
+    }, [searchParams])
 
     const handleLogout = async () => {
         await supabase.auth.signOut()


### PR DESCRIPTION
## Summary
- Fix upgrade buttons in PDF components that were not properly redirecting to the subscription tab
- Users clicking "Upgrade to Premium" buttons now correctly land on /profile?tab=subscription with the subscription tab active

## Changes Made
- Add URL parameter reading in `ProfileLayout` component using `useSearchParams`  
- Implement automatic tab switching based on URL `tab` parameter
- Add proper Suspense wrapper for `useSearchParams` compatibility
- Maintain existing redirect URLs in `PdfExportControls` and `TemplateSelector` components

## Test Plan
- [x] Click upgrade button in PDF export controls → should open subscription tab
- [x] Click upgrade button in template selector → should open subscription tab  
- [x] Direct navigation to /profile?tab=subscription → should open subscription tab
- [x] TypeScript compilation passes
- [x] No breaking changes to existing profile page functionality

🤖 Generated with [Claude Code](https://claude.ai/code)